### PR TITLE
Added -wsl flag, goes after address, changes PATH for WSL #2

### DIFF
--- a/scripts/build.py
+++ b/scripts/build.py
@@ -7,7 +7,13 @@ import hashlib
 import subprocess
 import sys
 
+# Default path for Windows
 PATH = 'C:/devkitPro/devkitARM/bin'
+
+# Check for the '-wsl' flag in the arguments
+if len(sys.argv) > 2 and sys.argv[2] == '-wsl':
+    PATH = '/usr/bin'
+
 PREFIX = '/arm-none-eabi-'
 AS = (PATH + PREFIX + 'as')
 CC = (PATH + PREFIX + 'gcc')


### PR DESCRIPTION
This branch adds an optional flag for WSL users

e.g. to insert at address `<A00000>`, WSL users can run the following command:
`python3 scripts/build.py 0x08A00000 -wsl`

---

# Here's how I built and ran this repository from WSL:
**These instructions assume you are using WSL, and do not yet have `grit` or `armips`**

`git clone https://github.com/DgZiga/FR-3dCutscenes.git`
`cd FR-3dCutscenes`
`git clone https://github.com/devkitPro/grit/`
`cd grit`
`sudo apt-get install autoconf automake libtool libfreeimage-dev`
`./autogen.sh`
`./configure`
`make`
`sudo make install`
`git clone https://github.com/Kingcom/armips.git`
`cd armips`
`mkdir build`
`cd build`
`git submodule update --init --recursive`
`cmake ..`
`make`
`sudo cp armips/build/armips /usr/local/bin/`
`cd ../..`
`python3 scripts/build.py 0x08A00000 -wsl`
(Or another address, with the prefix 0x08, before your 6 digit address)